### PR TITLE
Added MD5 Checksum Support

### DIFF
--- a/config.go
+++ b/config.go
@@ -140,6 +140,10 @@ type Config struct {
 	//
 	// This parameter can be provided multiple times.
 	Ignore []*regexp.Regexp
+
+	// MD5Checksum is a flag that, when set to true, indicates to calculate
+	// MD5 checksums for files.
+	MD5Checksum bool
 }
 
 // NewConfig returns a default configuration struct.

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -48,6 +48,7 @@ func parseArgs() *bindata.Config {
 	flag.BoolVar(&c.NoMemCopy, "nomemcopy", c.NoMemCopy, "Use a .rodata hack to get rid of unnecessary memcopies. Refer to the documentation to see what implications this carries.")
 	flag.BoolVar(&c.NoCompress, "nocompress", c.NoCompress, "Assets will *not* be GZIP compressed when this flag is specified.")
 	flag.BoolVar(&c.NoMetadata, "nometadata", c.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
+	flag.BoolVar(&c.MD5Checksum, "md5checksum", c.MD5Checksum, "MD5 checksums will be calculated for assets.")
 	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")
 	flag.Int64Var(&c.ModTime, "modtime", c.ModTime, "Optional modification unix timestamp override for all files.")
 	flag.StringVar(&c.Output, "o", c.Output, "Optional name of the output file to be generated.")


### PR DESCRIPTION
This patch adds support for creating embedded files with their MD5
checksum calculated at time of the buffer generation and stored
alongside the asset information. The checksum feature can be enabled via
the command line with the `--md5checksum` flag. The default value for
the flag is `false`.